### PR TITLE
Modify log rotation policy for http-request logs to limit total log size

### DIFF
--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/concurrent/pom.xml
+++ b/concurrent/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/dbpool/pom.xml
+++ b/dbpool/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/discovery/pom.xml
+++ b/discovery/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/event/pom.xml
+++ b/event/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/http-utils/pom.xml
+++ b/http-utils/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>airlift</artifactId>
         <groupId>com.facebook.airlift</groupId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/jaxrs-testing/pom.xml
+++ b/jaxrs-testing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/jmx-http-rpc/pom.xml
+++ b/jmx-http-rpc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/jmx-http/pom.xml
+++ b/jmx-http/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>airlift</artifactId>
         <groupId>com.facebook.airlift</groupId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/log-manager/pom.xml
+++ b/log-manager/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/log/pom.xml
+++ b/log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.facebook.airlift</groupId>
     <artifactId>airlift</artifactId>
     <packaging>pom</packaging>
-    <version>0.208-SNAPSHOT</version>
+    <version>0.207.1</version>
 
     <name>airlift</name>
     <description>Airlift</description>
@@ -25,7 +25,7 @@
         <air.check.skip-license>true</air.check.skip-license>
         <air.java.version>1.8.0-40</air.java.version>
 
-        <dep.airlift.version>0.208-SNAPSHOT</dep.airlift.version>
+        <dep.airlift.version>0.207.1</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.jetty.version>9.4.14.v20181114</dep.jetty.version>
         <dep.jersey.version>2.26</dep.jersey.version>
@@ -52,7 +52,7 @@
         <connection>scm:git:git://github.com/airlift/airlift.git</connection>
         <developerConnection>scm:git:git@github.com:airlift/airlift.git</developerConnection>
         <url>https://github.com/airlift/airlift/tree/master</url>
-        <tag>HEAD</tag>
+        <tag>0.207.1</tag>
     </scm>
 
     <modules>

--- a/sample-server/pom.xml
+++ b/sample-server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/skeleton-server/pom.xml
+++ b/skeleton-server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/stats/pom.xml
+++ b/stats/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>

--- a/trace-token/pom.xml
+++ b/trace-token/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.208-SNAPSHOT</version>
+        <version>0.207.1</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
The expected behaviour of the below config properties:

- http-server.log.max-history to limit number of log files
- http-server.log.max-size to limit the size of each log file

However, these get passed to logback where max history is treated as
"number of archive log periods to keep". The log period is derived
from log file name pattern, i.e. day in our case.

This commit has introduced the use of the parameter TotalSizeCap to simulate the expected behaviour.

More information: https://logback.qos.ch/manual/appenders.html#tbrpTotalSizeCap